### PR TITLE
Created more advanced tag modeling functionality. Now when tag field tok...

### DIFF
--- a/src/BitMemory.h
+++ b/src/BitMemory.h
@@ -135,7 +135,7 @@ public:
 
 	void GetBytes(uchar *data, uint32 n_bytes)
 	{
-		ASSERT(position + n_bytes < size);
+		ASSERT(position + n_bytes <= size);
 
 		std::copy(memory + position, memory + position + n_bytes, data);
 		position += n_bytes;

--- a/src/BlockCompressor.h
+++ b/src/BlockCompressor.h
@@ -76,7 +76,8 @@ protected:
 	enum FastqBlockFlags
 	{
 		FLAG_DELTA_CONSTANT			= BIT(0),
-		FLAG_VARIABLE_LENGTH		= BIT(1)
+		FLAG_VARIABLE_LENGTH		= BIT(1),
+		FLAG_MIXED_FIELD_FORMATTING	= BIT(2)		// this should be handled by TagModelerProxy*
 	};
 
 	const fq::FastqDatasetType datasetType;
@@ -90,7 +91,6 @@ protected:
 	TagModeler tagModeler;
 	IDnaModelerProxy* dnaModeler;
 	IQualityModeler* qualityModeler;
-
 
 	void ParseRecords(const fq::FastqDataChunk& chunk_);
 

--- a/src/BlockCompressorExt.cpp
+++ b/src/BlockCompressorExt.cpp
@@ -1,3 +1,12 @@
+/*
+  This file is a part of DSRC software distributed under GNU GPL 2 licence.
+  The homepage of the DSRC project is http://sun.aei.polsl.pl/dsrc
+
+  Authors: Lucas Roguski and Sebastian Deorowicz
+
+  Version: 2.00
+*/
+
 #include "BlockCompressorExt.h"
 
 namespace dsrc

--- a/src/Common.h
+++ b/src/Common.h
@@ -199,6 +199,7 @@ class HuffmanEncoder;
 namespace core
 {
 
+class Buffer;
 class BitMemoryReader;
 class BitMemoryWriter;
 class ErrorHandler;

--- a/src/DsrcFile.h
+++ b/src/DsrcFile.h
@@ -33,7 +33,7 @@ struct DsrcFileHeader
 
 	static const uint32 VersionMajor = 2;
 	static const uint32 VersionMinor = 0;
-	static const uint32 VersionRev = 0;
+	static const uint32 VersionRev = 1;
 
 	uchar	dummyByte;
 	uchar	versionMajor;

--- a/src/TagModeler.h
+++ b/src/TagModeler.h
@@ -32,6 +32,8 @@ struct Field
 {
 	static const uint32 HUF_GLOBAL_SIZE = 512;
 	static const uint32 HUF_LOCAL_SIZE = 256;
+	static const uint32 MAX_FIELD_STAT_LEN = 128;
+	static const uint32 MAX_NUM_VAL_HUF	= 512;
 
 	uint32 len;
 	uint32 min_len;
@@ -96,40 +98,244 @@ struct Field
 };
 
 
-class TagModeler
+struct TagStats
+{
+	static const uint32 MaxSymbolCount = 128;
+
+	std::vector<Field> fields;
+	uint32 minTitleLen;
+	uint32 maxTitleLen;
+	uint32 symbolFreqs[MaxSymbolCount];
+	bool mixedFormatting;
+
+	TagStats()
+	{
+		Reset();
+	}
+
+	void Reset()
+	{
+		fields.clear();				// TODO: reset fields, do not delete!
+		minTitleLen = 0xFFFFFFFF;
+		maxTitleLen = 0;
+		std::fill(symbolFreqs, symbolFreqs + MaxSymbolCount, 0);
+		mixedFormatting = false;
+	}
+};
+
+
+class TagAnalyzer
 {
 public:
-	TagModeler()
-		:	recordCounter(0)
-	{}
-
 	void InitializeFieldsStats(const fq::FastqRecord& rec_);
 	void UpdateFieldsStats(const fq::FastqRecord& rec_);
 	void FinalizeFieldsStats();
 
-	void StartEncoding(core::BitMemoryWriter& writer_);
-	void EncodeNextFields(core::BitMemoryWriter& writer_, const fq::FastqRecord& rec_);
-	void FinishEncoding(core::BitMemoryWriter& writer_);
-
-	void StartDecoding(core::BitMemoryReader& reder_);
-	void DecodeNextFields(core::BitMemoryReader& reader_, fq::FastqRecord& rec_);
-	void FinishDecoding(core::BitMemoryReader& reader_);
+	TagStats& GetStats()
+	{
+		return stats;
+	}
 
 private:
-	static const uint32 MAX_FIELD_STAT_LEN = 128;
-	static const uint32 MAX_NUM_VAL_HUF	= 512;
-
-	std::vector<Field> fields;
+	TagStats stats;
 	std::vector<int32> prevFieldValues;
 	uint32 recordCounter;
 
 	void UpdateNumericField(Field& field_, int32 curValue_, int32 prevValue_);
+};
+
+
+class ITagEncoder
+{
+public:
+	ITagEncoder()
+	{}
+
+	virtual ~ITagEncoder() {}
+
+	virtual void StartEncoding(core::BitMemoryWriter& writer_, TagStats* stats_) = 0;
+	virtual void EncodeNextFields(core::BitMemoryWriter& writer_, const fq::FastqRecord& rec_) = 0;
+	virtual void FinishEncoding(core::BitMemoryWriter& writer_) = 0;
+};
+
+
+class ITagDecoder
+{
+public:
+	virtual ~ITagDecoder() {}
+
+	virtual void StartDecoding(core::BitMemoryReader& reader_) = 0;
+	virtual void DecodeNextFields(core::BitMemoryReader& reader_, fq::FastqRecord& rec_) = 0;
+	virtual void FinishDecoding(core::BitMemoryReader& reader_) = 0;
+};
+
+
+class ITagTokenizer
+{
+public:
+	ITagTokenizer()
+		:	recordCounter(0)
+	{}
+
+protected:
+	std::vector<int32> prevFieldValues;
+	uint32 recordCounter;
+};
+
+
+class TagTokenizerEncoder : public ITagTokenizer, public ITagEncoder
+{
+public:
+	TagTokenizerEncoder()
+		:	stats(NULL)
+	{}
+
+	void StartEncoding(core::BitMemoryWriter& writer_, TagStats* stats_);
+	void EncodeNextFields(core::BitMemoryWriter& writer_, const fq::FastqRecord& rec_);
+	void FinishEncoding(core::BitMemoryWriter& writer_);
+
+private:
+	TagStats* stats;
 
 	void StoreFields(core::BitMemoryWriter &bit_stream);
 	void StoreNumericField(core::BitMemoryWriter& bit_memory, Field& field_, int32 curValue_, int32 prevValue_);
+};
+
+
+class TagTokenizerDecoder : public ITagTokenizer, public ITagDecoder
+{
+public:
+	void StartDecoding(core::BitMemoryReader& reader_);
+	void DecodeNextFields(core::BitMemoryReader& reader_, fq::FastqRecord& rec_);
+	void FinishDecoding(core::BitMemoryReader& reader_);
+
+private:
+	TagStats stats;
 
 	void ReadFields(core::BitMemoryReader &bit_stream);
 	uint32 ReadNumericField(core::BitMemoryReader& bit_stream, Field& field_, int32 prevValue_);
+};
+
+
+class ITagRawCoder
+{
+public:
+	ITagRawCoder()
+		:	symbolCount(0)
+		,	titleLenBits(0)
+		,	encoder(NULL)
+	{}
+
+	virtual ~ITagRawCoder()
+	{
+		if (encoder)
+			delete encoder;
+	}
+
+protected:
+	static const uint32 MaxSymbolCount = 128;
+	static const char EmptySymbol = -1;
+
+	uint32 symbolCount;
+	char symbols[MaxSymbolCount];
+	uint32 titleLenBits;
+	HuffmanEncoder* encoder;		// try non-dynamic + Reset()
+};
+
+
+class TagRawEncoder : public ITagEncoder, ITagRawCoder
+{
+public:
+	TagRawEncoder()
+		:	stats(NULL)
+	{}
+
+	void StartEncoding(core::BitMemoryWriter& writer_, TagStats* stats_);
+	void EncodeNextFields(core::BitMemoryWriter& writer_, const fq::FastqRecord& rec_);
+	void FinishEncoding(core::BitMemoryWriter& writer_);
+
+private:
+	TagStats* stats;
+};
+
+
+class TagRawDecoder : public ITagDecoder, ITagRawCoder
+{
+public:
+	TagRawDecoder()
+		:	minTitleLen(0)
+		,	maxTitleLen(0)
+	{}
+
+	void StartDecoding(core::BitMemoryReader& reader_);
+	void DecodeNextFields(core::BitMemoryReader& reader_, fq::FastqRecord& rec_);
+	void FinishDecoding(core::BitMemoryReader& reader_);
+
+private:
+	uint32 minTitleLen;
+	uint32 maxTitleLen;
+};
+
+
+class TagModeler
+{
+public:
+	enum TagEncodingScheme
+	{
+		TagTokenizeHuffman = 0,
+		TagRawHuffman
+	};
+
+	TagModeler()
+		:	analyzer(NULL)
+	{
+		encoders[0] = encoders[1] = NULL;
+		decoders[0] = decoders[1] = NULL;
+	}
+
+	~TagModeler()
+	{
+		if (encoders[0] != NULL) delete encoders[0];
+		if (encoders[1] != NULL) delete encoders[1];
+		if (decoders[0] != NULL) delete decoders[0];
+		if (decoders[1] != NULL) delete decoders[1];
+	}
+
+	ITagEncoder* SelectEncoder(TagEncodingScheme scheme_)
+	{
+		if (encoders[scheme_] == NULL)
+		{
+			if (scheme_ == TagTokenizeHuffman)
+				encoders[scheme_] = new TagTokenizerEncoder();
+			else
+				encoders[scheme_] = new TagRawEncoder();
+		}
+		return encoders[scheme_];
+	}
+
+	ITagDecoder* SelectDecoder(TagEncodingScheme scheme_)
+	{
+		if (decoders[scheme_] == NULL)
+		{
+			if (scheme_ == TagTokenizeHuffman)
+				decoders[scheme_] = new TagTokenizerDecoder();
+			else
+				decoders[scheme_] = new TagRawDecoder();
+		}
+		return decoders[scheme_];
+	}
+
+	TagAnalyzer* GetAnalyzer()
+	{
+		if (analyzer == NULL)
+			analyzer = new TagAnalyzer();
+		return analyzer;
+	}
+
+private:
+	TagAnalyzer* analyzer;
+	ITagEncoder* encoders[2];
+	ITagDecoder* decoders[2];
 };
 
 } // namespace comp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 #include "DsrcOperator.h"
 #include "utils.h"
 
-const std::string version = "2.00 @ 06.05.2014";
+const std::string version = "2.01 @ 28.05.2014";
 
 using namespace dsrc;
 using namespace dsrc::core;


### PR DESCRIPTION
This fix enables compression of FASTQ files consisting of non-uniform TAG fields inside the same FASTQ block. Previously, while compressing concatenated FASTQ files from different experiments with different TAG field characteristics, DSRC could have crashed or compressed improperly.
